### PR TITLE
enlightning bug

### DIFF
--- a/dew.css
+++ b/dew.css
@@ -69,10 +69,24 @@ https://github.com/s9a/dew
   --dew-hyper: var(--dew-focus);
 }
 
-.dew-polar,
-.dew-lunar {
+.dew-media {
+  --dew-oil: var(--dew-media);
+  --dew-ink: var(--dew-polar);
+}
+
+.dew-polar {
   --dew-oil: var(--dew-polar);
   --dew-ink: var(--dew-media);
+}
+
+.dew-solar {
+  --dew-oil: var(--dew-solar);
+  --dew-ink: var(--dew-lunar);
+}
+
+.dew-lunar {
+  --dew-oil: var(--dew-lunar);
+  --dew-ink: var(--dew-solar);
 }
 
 @media (prefers-color-scheme: dark) {


### PR DESCRIPTION
### [some scenarios](https://s9a.page/dew/#cascade) defied their intent

> `.dew-media` matches `media`
> `.dew-polar` opposes `media`
> `.dew-solar` depicts `light`
> `.dew-lunar` depicts `dark`

### #11 ensures

* media matches media
* polar opposes polar
* solar stays solar
* lunar stays lunar
* light is solar
* dark is lunar