### PR TITLE
bypass transition when user prefers reduced motion

### DIFF
--- a/dew.css
+++ b/dew.css
@@ -2,9 +2,11 @@
 https://github.com/s9a/dew
 */
 
-.dew-shift *,
-.dew-shift {
-  transition: var(--dew-shift);
+@media (prefers-reduced-motion: no-preference) {
+  .dew-shift *,
+  .dew-shift {
+    transition: var(--dew-shift);
+  }
 }
 
 .dew-wet *,


### PR DESCRIPTION
[prefers-reduced-motion](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion) mainly relates to animation but because our transition is variable this progressive enhancement [no motion first approach](https://www.tatianamac.com/posts/prefers-reduced-motion/) seems like safer design and [respects users](https://www.smashingmagazine.com/2021/10/respecting-users-motion-preferences/) who chose reduced motion for whatever reason [including afflictions](https://www.w3.org/WAI/WCAG21/Understanding/animation-from-interactions) or [battery life](https://developer.mozilla.org/en-US/docs/Web/Performance/Fundamentals)